### PR TITLE
Operational modes for Flyio adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 ![Nats Pillow icon](https://github.com/user-attachments/assets/7fd40216-2a5d-4ca8-b53e-04710038e718)
 
-
 # NATS Pillow
 A soft little wrapper for NATS, to remove the boilerplate for certain use cases, mainly running NATS embedded in Go.
 
+> [!WARNING]
+> The Pillow API is unstable until v1.0.0 and as such may be subject to change in future releases until v1.0.0 is released.
+
 ## Features
-- Flyio Adapter (auto clustering w/ route updates, node naming based on fly machine ID)
-- Boilerplate for using NATS embedded in go
+- Remove boilerplate when using NATS embedded in Go
+- Flyio Adapters (auto clustering w/ route updates, node naming based on fly machine ID)
+  - Clustering: Auto clustering in region, supercluster regions together.
+  - HubAndSpoke: Auto cluster primary region, and leaf node other regions' machines to your hub.
+- <Your needed feature here>? Leave a feature request issue!
 
 ## Examples
-Reference the [examples folder](./examples) for examples of using nats-pillow. Additionally, this project was started and is being maintained to be used in the [Stelo Finance](https://github.com/stelofinance/stelofinance) project, so check that out for a real project example. 
+- Reference the [examples folder](./examples) for examples of using nats-pillow.
+- This project was started and is being maintained to be used in the [Stelo Finance](https://github.com/stelofinance/stelofinance) project, so check that out for a real project example. 
 
-## Quirks w/ Flyio Adapter
-- Removing a region will cause any remaining machines will infinitely try to reconnect to the removed region, until they are restarted. This is probably fine, as it's just some network calls, but it is something to be aware of.
-- When JetStream is enabled you need to explicitly pass the regions you want it to be enabled on in the Adapter options. This behavior will hopefully be improved in the future.
-- Scaling down a JetStream enabled region may cause the JS quorum to fail, or the meta leader to not be established. This renders JS unuseable, and will hopefully be fixed or addressed in a future release.
+## Quirks with Platform Adapters
+- FlyioClustering: Removing a region will cause any remaining machines will infinitely try to reconnect to the removed region, until they are restarted. This is probably fine, as it's just some network calls, but it is something to be aware of.
+- FlyioClustering: When JetStream is enabled all your regions must have >= 3 nodes, as JetStream clustering requires this for a quorum.
+- Flyio (Clustering & HubAndSpoke): Scaling down a JetStream enabled region may cause the JS quorum to fail, or the meta leader to not be established. This renders JS unuseable, and will hopefully be fixed or addressed in a future release.
+
+> [!CAUTION]
+> Take great caution when switching adapters (such as HubAndSpoke to Clustering) as the cluster names and JS domains will change. Along with scaling down JS regions, as there seems to be a bug with quorums failing.
 
 *Credit to [@whaaaley](https://github.com/whaaaley) for project name and icon*

--- a/pillow/adapters.go
+++ b/pillow/adapters.go
@@ -9,98 +9,46 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/nats-io/nats-server/v2/server"
 )
 
-type FlyioOptions struct {
-	// Configure how the Flyio Adapter will organize your NATS topology.
-	//
-	// ClusteringMode will cluster all intra-region machines, and super cluster regions together.
-	// Note, if JS is enabled ALL regions must have >= 3 machines.
-	//
-	// HubAndSpokeMode requires you to configure a hub region (or regions) and then all machines in
-	// other regions will connect to the hub as leaf nodes.
-	//
-	// ConstellationMode will connect all regions together using leaf node.
-	//
-	// CustomMode allows you to configure exactly how you want your regions to be organized.
-	OperationalMode OperationalMode
+const (
+	ClusterPort  int = 4244
+	GatewayPort  int = 7244
+	LeafNodePort int = 7422
+)
 
-	// Configure how the Flyio Adapter handles its Clustering mode.
-	ClusteringOptions ClusteringModeOptions
-
-	// Configure how the Flyio Adapter handles its HubAndSpoke mode.
-	HubAndSpokeOptions HubAndSpokeModeOptions
-
-	// Configure how the Flyio Adapter handles its Constellation mode.
-	ConstellationOptions ConstellationModeOptions
+type PlatformConfigurator interface {
+	Configure(context.Context) Option
 }
 
-type ClusteringModeOptions struct {
+// FlyioClustering will cluster all intra-region machines, and super cluster regions together.
+// Note, if JetStream is enabled ALL regions must have >= 3 machines.
+type FlyioClustering struct {
 	// The name to be used for clustering. Appended will be `-<REGION>` where REGION is the
 	// Flyio region this cluster is in.
 	ClusterName string
 }
 
-type HubAndSpokeModeOptions struct {
-	// The regions that should be clustered and superclustered together.
-	//
-	// If only one region is passed then superclustering will be disabled.
-	HubRegions []string
-
-	// The name to be used for the hub's cluster(s).
-	//
-	// If there is multiple entries in HubRegions then `-<REGION>` (where REGION is the
-	// Flyio region) will be appended.
+// FlyioHubAndSpoke will cluster all machines in your primary region, and then all other
+// regions will have their machines individually connect to your primary region cluster
+// as leaf nodes.
+//
+// Additionally, the primary region cluster will have the JS domain of "hub" and the leaf nodes
+// will have the structure of "leaf-<REGION>-<MACHINE_ID>"
+type FlyioHubAndSpoke struct {
+	// The name to be used for the primary region cluster.
 	ClusterName string
 }
 
-type ConstellationModeOptions struct {
-	// If set to true then clustering within regions will be disabled.
-	//
-	// Note, regions passed in ClusteredRegions will still have clustering enabled.
-	DisableClustering bool
-
-	// Configure which regions should be clustered. If array isn't empty then ONLY the
-	// regions passed will have clustering enabled.
-	ClusteredRegions []string
-}
-
-type manualModeOptions struct {
-}
-
-type OperationalMode int
-
-const (
-	ClusteringMode OperationalMode = iota
-	HubAndSpokeMode
-	ConstellationMode
-	CustomMode
-)
-
-const (
-	ClusterPort int = 4232
-	GatewayPort int = 4242
-)
-
-// Configures the server to run in the Flyio environment. Will cluster all machines in the same app and region
-// and supercluster different regions together. This Option should be used last, as it overrides specific
-// options like JetStream, to achieve the opinionated behavior.
-func AdapterFlyio(enable bool, opts FlyioOptions) Option {
-	if !enable {
-		return func(o *options) error { return nil }
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-
+func (c *FlyioClustering) Configure(ctx context.Context) Option {
 	env, err := flyioGetEnvVars()
 	if err != nil {
 		return func(o *options) error { return err }
 	}
 
-	inRegionRoutes, err := getRoutesFlyio(ctx, &env)
+	inRegionRoutes, err := flyioGetRegionURLs(ctx, &env, env.region, "nats", ClusterPort)
 	if err != nil {
 		// Do nothing, regions will be empty until there is a resolution to
 		// this post: https://community.fly.io/t/machine-cannot-read-its-own-internal-dns-entry-on-startup/23278
@@ -117,54 +65,44 @@ func AdapterFlyio(enable bool, opts FlyioOptions) Option {
 		inRegionRoutes = append(inRegionRoutes, selfURL)
 	}
 
-	clusterName := opts.ClusterName
+	clusterName := c.ClusterName + "-" + env.region
 	var gatewayOpts server.GatewayOpts
 
-	if !opts.DisableSuperClustering {
-		clusterName += "-" + env.region
-		regions, err := getRegionsFlyio(ctx, &env)
-		if err != nil {
-			// Do nothing, regions will be empty until there is a resolution to
-			// this post: https://community.fly.io/t/machine-cannot-read-its-own-internal-dns-entry-on-startup/23278
-			//
-			// return func(o *options) error { return err }
-		}
+	regions, err := getRegionsFlyio(ctx, &env)
+	if err != nil {
+		// Do nothing, regions will be empty until there is a resolution to
+		// this post: https://community.fly.io/t/machine-cannot-read-its-own-internal-dns-entry-on-startup/23278
+		//
+		// return func(o *options) error { return err }
+	}
 
-		gateways := make([]*server.RemoteGatewayOpts, 0)
-		for _, region := range regions {
-			urls := make([]*url.URL, 0, len(region.machines))
-			for _, machine := range region.machines {
-				gatewayUrl, err := url.Parse("nats://[" + machine.ip.String() + "]:" + strconv.Itoa(GatewayPort))
-				if err != nil {
-					return func(o *options) error {
-						return errors.New("Unable to parse NATS gateway url")
-					}
+	gateways := make([]*server.RemoteGatewayOpts, 0)
+	for _, region := range regions {
+		urls := make([]*url.URL, 0, len(region.machines))
+		for _, machine := range region.machines {
+			gatewayUrl, err := url.Parse("nats://[" + machine.ip.String() + "]:" + strconv.Itoa(GatewayPort))
+			if err != nil {
+				return func(o *options) error {
+					return errors.New("Unable to parse NATS gateway url")
 				}
-				urls = append(urls, gatewayUrl)
 			}
-
-			gateways = append(gateways, &server.RemoteGatewayOpts{
-				Name: opts.ClusterName + "-" + region.name,
-				URLs: urls,
-			})
+			urls = append(urls, gatewayUrl)
 		}
 
-		gatewayOpts = server.GatewayOpts{
-			Name:           clusterName,
-			Host:           env.privateIP,
-			Port:           GatewayPort,
-			ConnectRetries: 5,
-			Gateways:       gateways,
-		}
+		gateways = append(gateways, &server.RemoteGatewayOpts{
+			Name: c.ClusterName + "-" + region.name,
+			URLs: urls,
+		})
+	}
+
+	gatewayOpts = server.GatewayOpts{
+		Name:           clusterName,
+		Port:           GatewayPort,
+		ConnectRetries: 5,
+		Gateways:       gateways,
 	}
 
 	return func(o *options) error {
-		if o.NATSSeverOptions.JetStream {
-			if !slices.Contains(opts.JSRegions, env.region) {
-				o.NATSSeverOptions.JetStream = false
-			}
-		}
-
 		o.NATSSeverOptions.ServerName = "fly-" + env.machineID
 		o.NATSSeverOptions.Routes = inRegionRoutes
 		o.NATSSeverOptions.Gateway = gatewayOpts
@@ -173,48 +111,86 @@ func AdapterFlyio(enable bool, opts FlyioOptions) Option {
 			Name:           clusterName,
 			Port:           ClusterPort,
 		}
-
-		// if !opts.DisableRouteRefetching {
-		// 	go func() {
-		// 		for {
-		// 			time.Sleep(time.Second * 30)
-
-		// 			// Wait till server is started
-		// 			if o.server == nil {
-		// 				continue
-		// 			}
-
-		// 			// If server isn't running stop reloading routes
-		// 			if !o.server.Running() {
-		// 				return
-		// 			}
-
-		// 			var wg sync.WaitGroup
-		// 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		// 			wg.Add(1)
-		// 			go func() {
-		// 				defer cancel()
-		// 				defer wg.Done()
-
-		// 				err := flyioReloadRoutes(ctx, o, &opts, &env)
-		// 				if err != nil {
-		// 					// Not really sure what to do with this error
-		// 					return
-		// 				}
-		// 			}()
-		// 			wg.Wait()
-		// 		}
-		// 	}()
-		// }
-
 		return nil
 	}
 }
 
+func (c *FlyioHubAndSpoke) Configure(ctx context.Context) Option {
+	env, err := flyioGetEnvVars()
+	if err != nil {
+		return func(o *options) error { return err }
+	}
+
+	isPrimaryRegion := env.primaryRegion == env.region
+
+	urlProtocol := "nats"
+	urlPort := ClusterPort
+	if !isPrimaryRegion {
+		urlProtocol = "nats-leaf"
+		urlPort = LeafNodePort
+	}
+
+	primaryRegionURLs, err := flyioGetRegionURLs(ctx, &env, env.primaryRegion, urlProtocol, urlPort)
+	if err != nil {
+		// Do nothing, regions will be empty until there is a resolution to
+		// this post: https://community.fly.io/t/machine-cannot-read-its-own-internal-dns-entry-on-startup/23278
+		//
+		// return func(o *options) error { return err }
+	}
+	// Till issue above is fixed forcefully include self so that when JS is enabled it doesn't crash on
+	// startup from empty routes, unless it's not primary region, in that case return error as there
+	// isn't much we can do to recover from this.
+	if len(primaryRegionURLs) == 0 {
+		if isPrimaryRegion {
+			selfURL, err := url.Parse("nats://[" + env.privateIP + "]:" + strconv.Itoa(ClusterPort))
+			if err != nil {
+				return func(o *options) error { return errors.New("Unable to parse NATS gateway url") }
+			}
+			primaryRegionURLs = append(primaryRegionURLs, selfURL)
+		} else {
+			return func(o *options) error { return errors.New("Unable to get primary region routes") }
+		}
+	}
+
+	remotes := make([]*server.RemoteLeafOpts, 0)
+	if !isPrimaryRegion {
+		remotes = append(remotes, &server.RemoteLeafOpts{
+			URLs: primaryRegionURLs,
+		})
+	}
+
+	return func(o *options) error {
+		if isPrimaryRegion {
+			o.NATSSeverOptions.JetStreamDomain = "hub"
+			o.NATSSeverOptions.LeafNode = server.LeafNodeOpts{
+				Port: LeafNodePort,
+			}
+			o.NATSSeverOptions.Routes = primaryRegionURLs
+			o.NATSSeverOptions.Cluster = server.ClusterOpts{
+				ConnectRetries: 5,
+				Name:           c.ClusterName,
+				Port:           ClusterPort,
+			}
+		} else {
+			o.NATSSeverOptions.JetStreamDomain = "leaf-" + env.region + "-" + env.machineID
+			o.NATSSeverOptions.LeafNode = server.LeafNodeOpts{
+				Remotes: remotes,
+			}
+		}
+
+		o.NATSSeverOptions.ServerName = "fly-" + env.machineID
+		return nil
+	}
+}
+
+func WithPlatformAdapter(ctx context.Context, enable bool, platformCfgr PlatformConfigurator) Option {
+	return platformCfgr.Configure(ctx)
+}
+
 // flyioReloadRoutes will fetch the current cluster and gateway routes, comparing them
 // to the server's current configuration and reloading if they have changed.
-func flyioReloadRoutes(ctx context.Context, opts *options, _ *FlyioOptions, env *flyioEnv) error {
-	inRegionroutes, err := getRoutesFlyio(ctx, env)
+func flyioReloadRoutes(ctx context.Context, opts *options, env *flyioEnv) error {
+	inRegionroutes, err := flyioGetRegionURLs(ctx, env, env.region, "nats", ClusterPort)
 	if err != nil {
 		return err
 	}
@@ -306,11 +282,12 @@ var ErrEnvVarNotFound = errors.New("Platform ENV not found")
 var ErrPlatformImplementationChanged = errors.New("Platform implementation changed")
 
 type flyioEnv struct {
-	machineID    string // FLY_MACHINE_ID
-	appName      string // FLY_APP_NAME
-	processGroup string // FLY_PROCESS_GROUP
-	region       string // FLY_REGION
-	privateIP    string // FLY_PRIVATE_IP
+	machineID     string // FLY_MACHINE_ID
+	appName       string // FLY_APP_NAME
+	processGroup  string // FLY_PROCESS_GROUP
+	region        string // FLY_REGION
+	privateIP     string // FLY_PRIVATE_IP
+	primaryRegion string // PRIMARY_REGION
 }
 
 func flyioGetEnvVars() (flyioEnv, error) {
@@ -333,6 +310,10 @@ func flyioGetEnvVars() (flyioEnv, error) {
 	}
 	env.privateIP = os.Getenv("FLY_PRIVATE_IP")
 	if env.privateIP == "" {
+		return flyioEnv{}, ErrEnvVarNotFound
+	}
+	env.primaryRegion = os.Getenv("PRIMARY_REGION")
+	if env.primaryRegion == "" {
 		return flyioEnv{}, ErrEnvVarNotFound
 	}
 
@@ -426,14 +407,14 @@ func getRegionsFlyio(ctx context.Context, env *flyioEnv) ([]regionInfo, error) {
 	return regionsArr, nil
 }
 
-// getRoutesFlyio will return a []*url.URL of the ips of machines in the same region
+// flyioGetRegionURLs will return a []*url.URL of the ips of machines in the same region
 // in the same process group.
-func getRoutesFlyio(ctx context.Context, env *flyioEnv) ([]*url.URL, error) {
+func flyioGetRegionURLs(ctx context.Context, env *flyioEnv, region string, protocol string, port int) ([]*url.URL, error) {
 	privateIp := net.ParseIP(env.privateIP)
 
 	var r net.Resolver
 	// lookup machines in same region
-	regionIPs, err := r.LookupIP(ctx, "ip6", env.region+"."+env.appName+".internal")
+	regionIPs, err := r.LookupIP(ctx, "ip6", region+"."+env.appName+".internal")
 	if err != nil {
 		return nil, err
 	}
@@ -447,10 +428,12 @@ func getRoutesFlyio(ctx context.Context, env *flyioEnv) ([]*url.URL, error) {
 
 	urls := make([]*url.URL, 0, len(ips))
 	for _, ip := range ips {
+		// TODO: Potentially remove? it's really fine if IP is in result
 		if ip.Equal(privateIp) {
 			continue
 		}
-		clusUrl, err := url.Parse("nats://[" + ip.String() + "]:" + strconv.Itoa(ClusterPort))
+
+		clusUrl, err := url.Parse(protocol + "://[" + ip.String() + "]:" + strconv.Itoa(port))
 		if err != nil {
 			return nil, errors.New("Unable to parse NATS gateway url")
 		}


### PR DESCRIPTION
Implement operational modes for the Flyio adapter, so different network topologies can be select by lib users. This PR is a direct implementation of the functionality defined in the operational modes issue (#9)

This will close #9 